### PR TITLE
Fix bug in operationHasParameter

### DIFF
--- a/src/main/groovy/com/smartbear/swagger/Swagger2Exporter.groovy
+++ b/src/main/groovy/com/smartbear/swagger/Swagger2Exporter.groovy
@@ -136,8 +136,9 @@ class Swagger2Exporter implements SwaggerExporter {
     }
 
     boolean operationHasParameter(Operation operation, String name) {
-        operation?.parameters.each { if (it.name == name) return true }
+        boolean found = false
+        operation?.parameters.each { if (it.name == name) found = true }
 
-        return false
+        return found
     }
 }


### PR DESCRIPTION
FYI this change is untested.

I'm new to Groovy, but it seems you can't return from inside the each{} block, which means operationHasParameter always returns false currently.