### PR TITLE
Definition refactoring fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-parser</artifactId>
-            <version>1.0.8-SNAPSHOT</version>
+            <version>1.0.8</version>
         </dependency>
 
         <dependency>

--- a/src/main/groovy/com/smartbear/swagger/Swagger1XImporter.groovy
+++ b/src/main/groovy/com/smartbear/swagger/Swagger1XImporter.groovy
@@ -25,6 +25,7 @@ import com.eviware.soapui.impl.rest.RestService
 import com.eviware.soapui.impl.rest.RestServiceFactory
 import com.eviware.soapui.impl.rest.support.RestParameter
 import com.eviware.soapui.impl.rest.support.RestParamsPropertyHolder.ParameterStyle
+import com.eviware.soapui.impl.wsdl.InterfaceFactoryRegistry
 import com.eviware.soapui.impl.wsdl.WsdlProject
 import com.smartbear.swagger4j.ApiDeclaration
 import com.smartbear.swagger4j.Parameter
@@ -44,10 +45,16 @@ class Swagger1XImporter implements SwaggerImporter {
 
     private final WsdlProject project
     private final String defaultMediaType;
+    private final boolean forRefactoring
 
     public Swagger1XImporter(WsdlProject project, String defaultMediaType) {
+        this(project, defaultMediaType, false)
+    }
+
+    public Swagger1XImporter(WsdlProject project, String defaultMediaType, boolean forRefactoring) {
         this.project = project
         this.defaultMediaType = defaultMediaType
+        this.forRefactoring = forRefactoring;
     }
 
     public Swagger1XImporter(WsdlProject project) {
@@ -191,7 +198,9 @@ class Swagger1XImporter implements SwaggerImporter {
     }
 
     private RestService createRestService(String path, String name) {
-        RestService restService = project.addNewInterface(name, RestServiceFactory.REST_TYPE)
+        RestService restService = forRefactoring ?
+                InterfaceFactoryRegistry.createNew(project, RestServiceFactory.REST_TYPE, name) :
+                project.addNewInterface(name, RestServiceFactory.REST_TYPE)
 
         if (path != null) {
             try {

--- a/src/main/groovy/com/smartbear/swagger/Swagger2Importer.groovy
+++ b/src/main/groovy/com/smartbear/swagger/Swagger2Importer.groovy
@@ -25,6 +25,7 @@ import com.eviware.soapui.impl.rest.RestService
 import com.eviware.soapui.impl.rest.RestServiceFactory
 import com.eviware.soapui.impl.rest.support.RestParameter
 import com.eviware.soapui.impl.rest.support.RestParamsPropertyHolder.ParameterStyle
+import com.eviware.soapui.impl.wsdl.InterfaceFactoryRegistry
 import com.eviware.soapui.impl.wsdl.WsdlProject
 import com.eviware.soapui.support.StringUtils
 import io.swagger.models.Operation
@@ -48,11 +49,17 @@ class Swagger2Importer implements SwaggerImporter {
 
     private final WsdlProject project
     private final String defaultMediaType;
+    private final boolean forRefactoring
     private static Logger logger = LoggerFactory.getLogger(Swagger2Importer)
 
     public Swagger2Importer(WsdlProject project, String defaultMediaType) {
+        this(project, defaultMediaType, false)
+    }
+
+    public Swagger2Importer(WsdlProject project, String defaultMediaType, boolean forRefactoring) {
         this.project = project
         this.defaultMediaType = defaultMediaType
+        this.forRefactoring = forRefactoring
     }
 
     public Swagger2Importer(WsdlProject project) {
@@ -221,7 +228,9 @@ class Swagger2Importer implements SwaggerImporter {
         if (name == null)
             name = path
 
-        RestService restService = project.addNewInterface(name, RestServiceFactory.REST_TYPE)
+        RestService restService = forRefactoring ?
+                InterfaceFactoryRegistry.createNew(project, RestServiceFactory.REST_TYPE, name) :
+                project.addNewInterface(name, RestServiceFactory.REST_TYPE)
         restService.description = swagger.info?.description
 
         if (swagger.host != null) {

--- a/src/main/groovy/com/smartbear/swagger/SwaggerUtils.groovy
+++ b/src/main/groovy/com/smartbear/swagger/SwaggerUtils.groovy
@@ -13,6 +13,7 @@ import groovy.json.JsonSlurper
  */
 class SwaggerUtils {
     public static final String DEFAULT_MEDIA_TYPE = "application/json";
+    public static final boolean DEFAULT_FOR_REFACTORING_VALUE = false;
 
     /**
      * Selects the appropriate SwaggerImporter for the specified URL. For .yaml urls the Swagger2Importer
@@ -26,13 +27,14 @@ class SwaggerUtils {
      * @return the corresponding SwaggerImporter based on the described "algorithm"
      */
 
-    static SwaggerImporter createSwaggerImporter(String url, WsdlProject project, String defaulMediaType) {
+    static SwaggerImporter createSwaggerImporter(String url, WsdlProject project, String defaulMediaType,
+                                                 boolean forRefactoring) {
 
         if (url.endsWith(".yaml"))
-            return new Swagger2Importer(project, defaulMediaType)
+            return new Swagger2Importer(project, defaulMediaType, forRefactoring)
 
         if (url.endsWith(".xml"))
-            return new Swagger1XImporter(project, defaulMediaType)
+            return new Swagger1XImporter(project, defaulMediaType, forRefactoring)
 
         def conn = new URL(url).openConnection()
         conn.addRequestProperty("Accept", "*/*")
@@ -40,13 +42,21 @@ class SwaggerUtils {
         def json = new JsonSlurper().parseText(conn.inputStream.text)
 
         if (String.valueOf(json?.swagger) == "2.0" || String.valueOf(json?.swaggerVersion) == "2.0")
-            return new Swagger2Importer(project, defaulMediaType)
+            return new Swagger2Importer(project, defaulMediaType, forRefactoring)
         else
-            return new Swagger1XImporter(project, defaulMediaType)
+            return new Swagger1XImporter(project, defaulMediaType, forRefactoring)
+    }
+
+    static SwaggerImporter createSwaggerImporter(String url, WsdlProject project, boolean forRefactoring) {
+        return createSwaggerImporter(url, project, DEFAULT_MEDIA_TYPE, forRefactoring)
+    }
+
+    static SwaggerImporter createSwaggerImporter(String url, WsdlProject project, String defaulMediaType) {
+        return createSwaggerImporter(url, project, defaulMediaType, DEFAULT_FOR_REFACTORING_VALUE)
     }
 
     static SwaggerImporter createSwaggerImporter(String url, WsdlProject project) {
-        return createSwaggerImporter(url, project, DEFAULT_MEDIA_TYPE)
+        return createSwaggerImporter(url, project, DEFAULT_MEDIA_TYPE, DEFAULT_FOR_REFACTORING_VALUE)
     }
 
     static SwaggerImporter importSwaggerFromUrl(


### PR DESCRIPTION
We began to use swagger plugin to refactor definition in Ready! API, but SwaggerImporter implementations added parsed interface description to the project, so after refactoring we had two interfaces instead of one (SOAP-4429). I added a parameter forRefactoring to createSwaggerImporter. If it is true, importer just create a RestService without adding it to the project. I left the old methods.
Also, replaced swagger-parser 1.0.8-SNAPSHOT with 1.0.8 in pom, as SNAPSHOT is no longer in nexus.